### PR TITLE
1.18.1 Compatability

### DIFF
--- a/data/cfc/functions/warp/create.mcfunction
+++ b/data/cfc/functions/warp/create.mcfunction
@@ -1,3 +1,3 @@
 summon marker ~ ~ ~ {Tags:["cfc","warp_point"]}
 forceload add ~ ~
-particle light ~ ~ ~ 0 0 0 1 1 normal
+particle block_marker shroomlight ~ ~ ~ 0 0 0 1 1 normal

--- a/data/cfc/functions/warp/locate.mcfunction
+++ b/data/cfc/functions/warp/locate.mcfunction
@@ -1,2 +1,2 @@
-execute positioned as @e[type=marker,tag=cfc,tag=warp_point,distance=..64] run particle light ~ ~ ~ 0 0 0 1 1 force
+execute positioned as @e[type=marker,tag=cfc,tag=warp_point,distance=..64] run particle block_marker shroomlight ~ ~ ~ 0 0 0 1 1 force
 execute unless entity @e[type=marker,tag=cfc,tag=warp_point,distance=..64] run tellraw @s "There are no Warp Points close to you"

--- a/data/cfc/functions/warp/remove.mcfunction
+++ b/data/cfc/functions/warp/remove.mcfunction
@@ -1,3 +1,3 @@
-execute positioned as @e[type=marker,limit=1,sort=nearest,tag=cfc,tag=warp_point,distance=..64] run particle barrier ~ ~ ~ 0 0 0 1 1 force
+execute positioned as @e[type=marker,limit=1,sort=nearest,tag=cfc,tag=warp_point,distance=..64] run particle block_marker barrier ~ ~ ~ 0 0 0 1 1 force
 execute positioned as @e[type=marker,limit=1,sort=nearest,tag=cfc,tag=warp_point,distance=..64] run forceload remove ~ ~
 execute positioned as @e[type=marker,limit=1,sort=nearest,tag=cfc,tag=warp_point,distance=..64] run kill @e[type=marker,limit=1,sort=nearest,tag=cfc,tag=warp_point,distance=..1]

--- a/data/cfc/functions/warp/remove.mcfunction
+++ b/data/cfc/functions/warp/remove.mcfunction
@@ -1,3 +1,5 @@
 execute positioned as @e[type=marker,limit=1,sort=nearest,tag=cfc,tag=warp_point,distance=..64] run particle block_marker barrier ~ ~ ~ 0 0 0 1 1 force
 execute positioned as @e[type=marker,limit=1,sort=nearest,tag=cfc,tag=warp_point,distance=..64] run forceload remove ~ ~
 execute positioned as @e[type=marker,limit=1,sort=nearest,tag=cfc,tag=warp_point,distance=..64] run kill @e[type=marker,limit=1,sort=nearest,tag=cfc,tag=warp_point,distance=..1]
+execute if entity @e[type=marker,limit=1,sort=nearest,tag=cfc,tag=warp_point,distance=..64] run tellraw @s ["",{"text":"Warp point removed","color":"red"}]
+execute unless entity @e[type=marker,limit=1,sort=nearest,tag=cfc,tag=warp_point,distance=..64] run tellraw @s ["",{"text":"There are no Warp Points close to you","color":"red"}]

--- a/data/cfc/functions/warp/remove_confirm.mcfunction
+++ b/data/cfc/functions/warp/remove_confirm.mcfunction
@@ -1,2 +1,2 @@
 tellraw @s ["",{"text":"Are you sure you want to remove this Warp Point?","bold":true,"underlined":true,"color":"dark_green"},{"text":"\n  ------\n| ","bold":true,"color":"dark_red"},{"text":""},{"text":"CONFIRM","color":"red","clickEvent":{"action":"run_command","value":"/function cfc:warp/remove"}},{"text":" |\n  ------","bold":true,"color":"dark_red"}]
-execute positioned as @e[type=marker,tag=cfc,tag=warp_point,distance=..64,limit=1,sort=nearest] run particle barrier ~ ~ ~ 0 0 0 1 1 force
+execute positioned as @e[type=marker,tag=cfc,tag=warp_point,distance=..64,limit=1,sort=nearest] run particle block_marker barrier ~ ~ ~ 0 0 0 1 1 force


### PR DESCRIPTION
1.18 update changed the syntax for the /particle command, such that "light" and "barrier" were collected into the new "block_marker", allowing any block texture to be used.
Further, the texture used for the light block has changed to indicate the light level, which isn't suited to the purpose of this pack, so it has been replaced with Shroomlight block texture.